### PR TITLE
Maintainability Indexを追加

### DIFF
--- a/complexity.go
+++ b/complexity.go
@@ -108,7 +108,7 @@ func countLOC(fs *token.FileSet, n *ast.FuncDecl) int {
 }
 
 // calcMaintComp calculates the maintainability index
-// source: https://docs.microsoft.com/ja-jp/archive/blogs/codeanalysis/maintainability-index-range-and-meaning
+// source: https://docs.microsoft.com/en-us/archive/blogs/codeanalysis/maintainability-index-range-and-meaning
 func calcMaintIndex(halstComp, cycloComp, loc int) int {
 	origVal := 171.0 - 5.2*math.Log(float64(halstComp)) - 0.23*float64(cycloComp) - 16.2*math.Log(float64(loc))
 	normVal := int(math.Max(0.0, origVal*100.0/171.0))


### PR DESCRIPTION
- Maintainability indexを計算 ([参考](https://docs.microsoft.com/en-us/archive/blogs/codeanalysis/maintainability-index-range-and-meaning))
- -maintunderで表示する上限を設定可能
- Cyclomatic complexityの部分を合わせて変更