### PR TITLE
calculating maintainability index for empty methods

### DIFF
--- a/complexity.go
+++ b/complexity.go
@@ -137,9 +137,19 @@ func countLOC(fs *token.FileSet, n *ast.FuncDecl) int {
 // calcMaintComp calculates the maintainability index
 // source: https://docs.microsoft.com/en-us/archive/blogs/codeanalysis/maintainability-index-range-and-meaning
 func calcMaintIndex(halstComp float64, cycloComp, loc int) int {
-	origVal := 171.0 - 5.2*math.Log(halstComp) - 0.23*float64(cycloComp) - 16.2*math.Log(float64(loc))
+
+	origVal := 171.0 - 5.2*logOf(halstComp) - 0.23*float64(cycloComp) - 16.2*logOf(float64(loc))
 	normVal := int(math.Max(0.0, origVal*100.0/171.0))
 	return normVal
+}
+
+func logOf(val float64) float64 {
+	switch val {
+	case 0:
+		return 0
+	default:
+		return math.Log(val)
+	}
 }
 
 func walkDecl(n ast.Node, opt map[string]int, opd map[string]int) {


### PR DESCRIPTION
log from 0 is infinity and maintainability index get screwed.

for example, for method:
```
func (c *aaa) BBB() {
	// TODO : destruction of cache
}
```
one would get:
`aaa.go:46:1: func BBB seems to have low maintainability (maintainability index=-9223372036854775808)`

after fixing it, the same would evaluate to:
`aaa.go:46:1: func BBB seems to have low maintainability (maintainability index=89)`
which i guess is more or less realistic.