### PR TITLE
Fix method operator counting

### DIFF
--- a/complexity.go
+++ b/complexity.go
@@ -160,6 +160,10 @@ func walkDecl(n ast.Node, opt map[string]int, opd map[string]int) {
 			opt["func"]++
 			opt[n.Name.Name]++
 			opt["()"]++
+		} else {
+			opt["func"]++
+			opt[n.Name.Name]++
+			opt["()"] += 2
 		}
 		walkStmt(n.Body, opt, opd)
 	}

--- a/testdata/src/halstead/a.go
+++ b/testdata/src/halstead/a.go
@@ -40,3 +40,9 @@ func f4() { // want "Cyclomatic complexity: 9, Halstead difficulty: 10.833, volu
 		}
 	}
 }
+
+type t1 struct {
+}
+
+func (t *t1) f5() { // want "Cyclomatic complexity: 1, Halstead difficulty: NaN, volume: 10.000"
+}


### PR DESCRIPTION
## Before
- Did not count the number of operators of methods
- As a result, the Halstead volume could be 0, which causes infinite maintainability index

## After
- Do count the number of operators of methods