### PR TITLE
change the version of golangci lint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           version: v1.29
           args: --skip-dirs=plugin


### PR DESCRIPTION
Fix the following errors caused by older golangci-lint-action.
> Error: The `set-env` command is disabled.
Error: The `add-path` command is disabled.